### PR TITLE
Publish CSV Outputs

### DIFF
--- a/bin/bam_count.py
+++ b/bin/bam_count.py
@@ -99,7 +99,7 @@ def main():
 
     args = parser.parse_args()
 
-    sample_name = os.path.basename(args.output_bam_file).rstrip('.bam')
+    sample_name = os.path.basename(args.output_bam_file)[:-len('.bam')]
     output_path = os.path.dirname(args.output_bam_file)
 
     readpair_counts = process_and_write_bam(

--- a/main.nf
+++ b/main.nf
@@ -11,6 +11,7 @@ process filter_bam {
     
     output:
         path "output/*.bam"
+        path "output/*_readpair_counts.csv"
 
     """#!/bin/bash
 set -e


### PR DESCRIPTION
This PR also includes a change to the Python code which removes the use of `.rstrip()`. While this isn't totally intuitive, using `.rstrip(".bam")` will strip off any `b`, `a`, or `m` characters which preceed the `.bam` suffix. For example:
![image](https://github.com/FredHutch/BAM-ReadPair-Processing/assets/5215560/25e27c8a-85e5-4ae3-aff7-bd0c369561a5)
